### PR TITLE
Add support for session persistence if set in the cloud service

### DIFF
--- a/src/borneo/client.py
+++ b/src/borneo/client.py
@@ -252,7 +252,13 @@ class Client(object):
     # set the session cookie if in return headers (see RequestUtils in http.py)
     @synchronized
     def set_session_cookie(self, cookie):
-        self._session_cookie = cookie
+        # only grab the "session=value" portion of the header
+        value = cookie.partition(';')[0]
+        if self._logutils.is_enabled_for(DEBUG):
+            self._logutils.log_debug(
+                'Set cookie value: ' + value)
+
+        self._session_cookie = value
 
     def check_request(self, request):
         # warn if using features not implemented at the connected server

--- a/src/borneo/http.py
+++ b/src/borneo/http.py
@@ -303,6 +303,15 @@ class RequestUtils(object):
                     res.set_rate_limit_delayed_ms(rate_delayed_ms)
                     # Copy retry stats to Result on successful operation.
                     res.set_retry_stats(self._request.get_retry_stats())
+
+                    # check for a Set-Cookie header
+                    cookie = response.headers.get('Set-Cookie', None)
+                    if cookie is not None and cookie.startswith('session='):
+                        self._client.set_session_cookie(cookie)
+                        if self._logutils.is_enabled_for(DEBUG):
+                            self._logutils.log_debug(
+                                'Set cookie value: ' + cookie)
+
                     return res
                 else:
                     res = HttpResponse(response.content.decode(),

--- a/src/borneo/http.py
+++ b/src/borneo/http.py
@@ -308,10 +308,6 @@ class RequestUtils(object):
                     cookie = response.headers.get('Set-Cookie', None)
                     if cookie is not None and cookie.startswith('session='):
                         self._client.set_session_cookie(cookie)
-                        if self._logutils.is_enabled_for(DEBUG):
-                            self._logutils.log_debug(
-                                'Set cookie value: ' + cookie)
-
                     return res
                 else:
                     res = HttpResponse(response.content.decode(),


### PR DESCRIPTION
If asked to set a session cookie, do so. This focuses requests from this session on a specific server in the backend set