### PR TITLE
Fix ImportError: cannot import name 'Callable' from 'collections' for Python 3.10+

### DIFF
--- a/src/borneo/stats.py
+++ b/src/borneo/stats.py
@@ -8,7 +8,12 @@
 import pprint
 import sys
 import uuid
-from collections import Callable
+try:
+    # Python 3.10+
+    from collections.abc import Callable
+except ImportError:
+    # fallback for Python 3.10-
+    from collections import Callable
 from datetime import datetime
 from logging import INFO
 from threading import Timer, Lock


### PR DESCRIPTION
In Python 3.10 the Callable class has been moved to the collections.abc module.

On Python 3.10:
```
Traceback (most recent call last):
  File "test.py", line 5, in <module>
    from borneo import (
  File ".pyenv/versions/oci/lib/python3.10/site-packages/borneo/__init__.py", line 24, in <module>
    from .driver import NoSQLHandle
  File ".pyenv/versions/oci/lib/python3.10/site-packages/borneo/driver.py", line 14, in <module>
    from .client import Client
  File ".pyenv/versions/oci/lib/python3.10/site-packages/borneo/client.py", line 28, in <module>
    from .stats import StatsControl
  File ".pyenv/versions/oci/lib/python3.10/site-packages/borneo/stats.py", line 11, in <module>
    from collections import Callable
ImportError: cannot import name 'Callable' from 'collections' (.pyenv/versions/3.10.1/lib/python3.10/collections/__init__.py)
```

Workaround:
```python
import collections.abc
collections.Callable = collections.abc.Callable
```