### PR TITLE
Token refresh for OKE Workload Principal

### DIFF
--- a/src/borneo/iam/iam.py
+++ b/src/borneo/iam/iam.py
@@ -449,7 +449,9 @@ class SignatureProvider(AuthorizationProvider):
                     or isinstance(self._provider, EphemeralResourcePrincipalSigner)
                 ):
                     self._provider.refresh_security_token()
-
+                    prov = self._provider
+                    if isinstance(prov, OkeWorkloadIdentityResourcePrincipalSigner):
+                        print(f"refresh security token = {prov.get_security_token()}")
                 self.get_signature_details_internal()
                 return
             except Exception as e:

--- a/src/borneo/iam/iam.py
+++ b/src/borneo/iam/iam.py
@@ -449,9 +449,7 @@ class SignatureProvider(AuthorizationProvider):
                     or isinstance(self._provider, EphemeralResourcePrincipalSigner)
                 ):
                     self._provider.refresh_security_token()
-                    prov = self._provider
-                    if isinstance(prov, OkeWorkloadIdentityResourcePrincipalSigner):
-                        print(f"refresh security token = {prov.get_security_token()}")
+
                 self.get_signature_details_internal()
                 return
             except Exception as e:

--- a/src/borneo/iam/iam.py
+++ b/src/borneo/iam/iam.py
@@ -23,6 +23,8 @@ try:
     # noinspection PyUnresolvedReferences
     from oci.auth.signers import InstancePrincipalsSecurityTokenSigner
     # noinspection PyUnresolvedReferences
+    from oci.auth.signers import OkeWorkloadIdentityResourcePrincipalSigner
+    # noinspection PyUnresolvedReferences
     from oci.auth.signers import get_resource_principals_signer
     # noinspection PyUnresolvedReferences
     from oci.config import from_file
@@ -309,7 +311,6 @@ class SignatureProvider(AuthorizationProvider):
                 'Principal the compartment for the operation must be specified.'
             )
 
-
     def set_service_url(self, config):
         service_url = config.get_service_url()
         if service_url is None:
@@ -440,12 +441,13 @@ class SignatureProvider(AuthorizationProvider):
         while True:
             try:
                 # refresh security token before create new signature
-                if (isinstance(
-                        self._provider,
-                        InstancePrincipalsSecurityTokenSigner) or
-                        isinstance(
-                            self._provider,
-                            EphemeralResourcePrincipalSigner)):
+                if (
+                    isinstance(self._provider, InstancePrincipalsSecurityTokenSigner)
+                    or isinstance(
+                        self._provider, OkeWorkloadIdentityResourcePrincipalSigner
+                    )
+                    or isinstance(self._provider, EphemeralResourcePrincipalSigner)
+                ):
                     self._provider.refresh_security_token()
 
                 self.get_signature_details_internal()


### PR DESCRIPTION
currently the refresh logic is only triggered for Instance principal and ephemeral resource principals. OKE Workload Principal is not a subclass of any of these. So I added it as another condition.

I tested it once by deploying it on our development cluster and re-running queries after 3 days. Let me know any integration or unit tests for this are needed.

Thanks.