### PR TITLE
Fixed error in WriteMultiple with multiple children-only requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - Cloud only: Fix thread used when rate limiting is enabled. Previously enabling
   rate limiting might cause a hang
+- Fixed error in WriteMultiple with multiple children-only requests
 
 # 5.4.2 - 2024-05-13
 

--- a/src/borneo/operations.py
+++ b/src/borneo/operations.py
@@ -3884,12 +3884,13 @@ class WriteMultipleRequest(Request):
         if table_name is None:
             self.set_table_name(request.get_table_name())
         else:
+            top_table = WriteMultipleRequest.get_top_table_name(table_name)
             if (WriteMultipleRequest.get_top_table_name(
                     request.get_table_name().lower())
-                    != table_name.lower()):
+                    != top_table.lower()):
                 raise IllegalArgumentException(
                     'The parent table_name used for the operation is '
-                    'different from that of others: ' + table_name)
+                    'different from that of others: ' + top_table)
         request.validate()
         self._ops.append(self.OperationRequest(request, abort_if_unsuccessful))
         return self


### PR DESCRIPTION
Changed logic to always check top-level table names. This fixes an error that happens when only child-table requests are added in WriteMultiple.